### PR TITLE
Fixed hyperlinks for Reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ npm i docsify-cli -g
 ```sh
 docsify serve .
 ```
+Documentation will be served at http://localhost:3000

--- a/api-testing.md
+++ b/api-testing.md
@@ -86,7 +86,7 @@ Assertions can be made by either using
 - `spec.response()` - prints request & response in terminal if the test case fails & keeps a track of the test case status. *(Recommended)*
 - `pactum.expect()` - Doesn't keep a track of the test case status. *(Not Recommended)*
 
-Reporting with this testing style differs. Learn more about it at [reporting](api-reporting)
+Reporting with this testing style differs. Learn more about it at [reporting](api-reporter)
 
 **Example - Cucumber**
 

--- a/contract-testing.md
+++ b/contract-testing.md
@@ -56,7 +56,7 @@ Once we publish the actual & assumed behavior to **PactumJS Flow Server**, pactu
 @enduml
 ```
 
-Flows & Interactions are published to PactumJS Flow Server using [pactum-flow-plugin](https://www.npmjs.com/package/pactum-flow-plugin). Learn more about reporters [here](api-reporting).
+Flows & Interactions are published to PactumJS Flow Server using [pactum-flow-plugin](https://www.npmjs.com/package/pactum-flow-plugin). Learn more about reporters [here](api-reporter).
 
 ## Pactum Flow Server
 


### PR DESCRIPTION
Fixing hyperlinks directing to reporters page.

Couple of hyperlinks were pointing to an incorrect path for reporter page.

Locations of the incorrect hyperlinks:
1. Navigate to [contract testing workflow](http://localhost:3000/#/contract-testing?id=workflow) and click on the reporters `here` hyperlink of the last line in the section.
2. Navigate to [Testing style](https://pactumjs.github.io/#/api-testing?id=testing-style) >> Bdd style tab and click on reporting hyperlink at the end of section

Both these instances route to a 404 page.