### PR TITLE
Fix broken links for api-testing.md

### DIFF
--- a/_navbar.md
+++ b/_navbar.md
@@ -1,6 +1,5 @@
 - **Tutorials**
   - [Quick Start](quick-start.md)
-  - [API Testing](api-testing.md)
   - [Request Making](request-making.md)
   - [Response Validation](response-validation.md)
   - [Integration Testing](integration-testing.md)

--- a/api-reporter.md
+++ b/api-reporter.md
@@ -38,7 +38,7 @@ after(async () => {
 
 ### Reporting for BDD
 
-The reporting structure for [Breaking](api-testing?id=testing-style) testing style differs as the `spec` runs in multiple steps. To have a proper reporting, we need to run additional methods.
+The reporting structure for [Breaking](test-setup?id=testing-style) testing style differs as the `spec` runs in multiple steps. To have a proper reporting, we need to run additional methods.
 
 - Run `settings.setReporterAutoRun(false)` before test execution.
 - Run `spec.end()` after each test case to let pactum know that test case has completed.

--- a/api-settings.md
+++ b/api-settings.md
@@ -128,7 +128,7 @@ Using the feature, will result in saving outputs in a local file system. By defa
 
 ### setReporterAutoRun
 
-The reporting structure for [Breaking](api-testing?id=testing-style) testing style differs as the `spec` runs in multiple steps. To have a proper reporting, we need to run additional methods.
+The reporting structure for [Breaking](test-setup?id=testing-style) testing style differs as the `spec` runs in multiple steps. To have a proper reporting, we need to run additional methods.
 
 - Run `settings.setReporterAutoRun(false)` before test execution.
 - Run `spec.end()` after each test case.

--- a/matching.md
+++ b/matching.md
@@ -48,7 +48,7 @@ It supports following matchers
 
 Matchers are applied on JSON
   
-- during response validation - [expectJsonMatch](api-testing#expectJsonMatch)
+- during response validation - [expectJsonMatch](response-validation?id=expectjsonmatch)
 - during request matching for interactions in [Mock Server](mock-server)
 - during request and response matching for [Contract Testing](contract-testing)
 

--- a/response-validation.md
+++ b/response-validation.md
@@ -36,7 +36,7 @@ Received response is validated through expectation methods. This library provide
 
 # Expectations Style
 
-Based on chosen [Testing Style](api-testing?id=testing-style), expectations methods are varied.
+Based on chosen [Testing Style](test-setup?id=testing-style), expectations methods are varied.
 
 <!-- tabs:start -->
 

--- a/welcome.md
+++ b/welcome.md
@@ -27,7 +27,7 @@ PactumJS users are typically Developers, QA Engineers and SDETs. It enables them
 
 > This tool will be a perfect fit for all kinds of API testing needs if you live in a world of **micro-services**.
 
-- [General API Testing](api-testing)
+- [General API Testing](request-making)
 - [Component Testing](component-testing)
 - [Contract Testing](contract-testing)
 - [Integration Testing](integration-testing)


### PR DESCRIPTION
`api-testing.md` was renamed to `request-making.md`. 

Broken links:
```
/#/api-testing
/#/api-testing?id=testing-style
/#/api-testing?id=expectjsonmatch
```

Updated the references to request-making.md.

Fixes #15 