### PR TITLE
Fix empty api pages

### DIFF
--- a/docs/api/assertions/expectJsonSnapshot.md
+++ b/docs/api/assertions/expectJsonSnapshot.md
@@ -11,7 +11,7 @@ Snapshot testing is a type of **output comparison** which will be very useful wh
 
 A typical snapshot test in pactum will fetch the api response, then compares it to a reference snapshot file stored alongside the test. The test will fail if the two snapshots do not match: either the change is unexpected, or the reference snapshot needs to be updated to the new version of the API response.
 
-If you are running the test for the first time, pactum will save the api response body at `./pactum/snapshots` directory. For the next test runs, pactum will compare the actual response with the local reference file. 
+If you are running the test for the first time, pactum will save the api response body at `.pactum/snapshots` directory. For the next test runs, pactum will compare the actual response with the local reference file. 
 
 > A snapshot needs a unique name & it can be defined through `spec().name("<unique name>")` or `expectJsonSnapshot("<name>")`.
 

--- a/docs/api/settings/setReporterAutoRun.md
+++ b/docs/api/settings/setReporterAutoRun.md
@@ -1,1 +1,44 @@
+---
+tags:
+  - reporter autorun
+  - reporter
+---
 # setReporterAutoRun
+
+sets reporter auto run option. Allows to disable reporter run after spec toss.
+
+> Defaults to `true`
+
+## Syntax
+
+```js
+setReporterAutoRun(boolean)
+```
+
+## Usage
+
+### ✅  Correct Usage
+
+```js
+settings.setReporterAutoRun(false)
+```
+
+## Arguments
+
+#### > option (boolean)
+
+Reporter auto run toggle.
+
+## Examples
+
+### Normal
+
+```js
+const { spec, request } = require('pactum');
+
+settings.setReporterAutoRun(false);
+
+await spec()
+  .get('/api/users/1')
+  .expectStatus(200);
+```

--- a/docs/api/settings/setRequestDefaultRetryCount.md
+++ b/docs/api/settings/setRequestDefaultRetryCount.md
@@ -1,1 +1,50 @@
+---
+tags:
+  - retry count
+  - request retry count
+---
+
 # setRequestDefaultRetryCount
+
+sets default retry count for requests.
+
+> Defaults to retry count 1
+
+## Syntax
+
+```js
+setRequestDefaultRetryCount(count)
+```
+
+## Usage
+
+### ✅  Correct Usage
+
+```js
+settings.setRequestDefaultRetryCount(2)
+```
+
+## Arguments
+
+#### > count (number)
+
+retry count.
+
+## Examples
+
+### Normal
+
+```js
+const { spec, settings } = require('pactum');
+
+settings.setRequestDefaultRetryCount(2);
+
+await spec()
+  .get('https://randomuser.me/api')
+  .expectStatus(200);
+```
+
+## See Also
+
+- [retry](/api/requests/retry)
+- [setRequestDefaultRetryDelay](/api/settings/setRequestDefaultRetryDelay)

--- a/docs/api/settings/setRequestDefaultRetryDelay.md
+++ b/docs/api/settings/setRequestDefaultRetryDelay.md
@@ -1,1 +1,64 @@
+---
+tags:
+  - retry delay
+  - request retry delay
+---
+
 # setRequestDefaultRetryDelay
+
+sets default retry delay for requests with retry enabled.
+
+> Defaults to 1000 milliseconds
+
+## Syntax
+
+```js
+setRequestDefaultRetryDelay(milliseconds)
+```
+
+## Usage
+
+### ✅  Correct Usage
+
+```js
+settings.setRequestDefaultRetryDelay(3000)
+```
+
+## Arguments
+
+#### > milliseconds (number)
+
+delay in milliseconds.
+
+## Examples
+
+### Normal
+
+```js
+const { spec, settings } = require('pactum');
+
+settings.setRequestDefaultRetryCount(2);
+settings.setRequestDefaultRetryDelay(2000);
+
+await spec()
+  .get('https://randomuser.me/api')
+  .expectStatus(200);
+```
+
+
+With retry
+```js
+const { spec, settings } = require('pactum');
+
+settings.setRequestDefaultRetryDelay(2000);
+
+await spec()
+  .get('https://randomuser.me/api')
+  .retry(2)
+  .expectStatus(200);
+```
+
+## See Also
+
+- [retry](/api/requests/retry)
+- [setRequestDefaultRetryCount](/api/settings/setRequestDefaultRetryCount)

--- a/docs/api/settings/setSnapshotDirectoryPath.md
+++ b/docs/api/settings/setSnapshotDirectoryPath.md
@@ -1,1 +1,50 @@
+---
+tags:
+  - snapshot directory path
+  - snapshot
+---
 # setSnapshotDirectoryPath
+
+sets snapshots directory path.
+
+> Defaults to `.pactum/snapshots` path
+
+## Syntax
+
+```js
+setSnapshotDirectoryPath(path)
+```
+
+## Usage
+
+### ✅  Correct Usage
+
+```js
+settings.setSnapshotDirectoryPath('new/path')
+```
+
+## Arguments
+
+#### > path (string)
+
+Snapshot directory path url.
+
+## Examples
+
+### Normal
+
+```js
+const { spec, request } = require('pactum');
+
+settings.setSnapshotDirectoryPath('new/path');
+
+await spec()
+  .name('snapshot directory test')
+  .get('/api/users/1')
+  .expectStatus(200)
+  .expectJsonSnapshot();
+```
+
+## See Also
+
+- [expectJsonSnapshot](/api/assertions/expectJsonSnapshot)


### PR DESCRIPTION
closes #23 

**Change Summary**
- Add missing docs for 
    - setReporterAutoRun (https://pactumjs.github.io/api/settings/setReporterAutoRun.html)
    - setRequestDefaultRetryCount (https://pactumjs.github.io/api/settings/setRequestDefaultRetryCount.html)
    - setSnapshotDirectoryPath (https://pactumjs.github.io/api/settings/setSnapshotDirectoryPath.html)
    - setRequestDefaultRetryDelay (https://pactumjs.github.io/api/settings/setRequestDefaultRetryDelay.html)