### PR TITLE
fix: typo within data management guide

### DIFF
--- a/docs/guides/data-management.md
+++ b/docs/guides/data-management.md
@@ -1,6 +1,6 @@
 # Data Management
 
-Data Management is one of the most powerful features of **PactumJS**. It allows us to logically group, reuse common date across all tests.
+Data Management is one of the most powerful features of **PactumJS**. It allows us to logically group, reuse common data across all tests.
 
 ## Introduction
 


### PR DESCRIPTION
There appears to be a small typo where `data` is spelled `date`. in docs/guides/data-management.md