### PR TITLE
add mockserver youtube links for tutorials

### DIFF
--- a/docs/media/videos.md
+++ b/docs/media/videos.md
@@ -1,9 +1,11 @@
 # Videos
 
-- [Introduction To PactumJS](https://www.youtube.com/watch?v=EBVWC5LG_eA) - Aamir Mohammed Suhail
-- [PactumJS and Cucumber - API Boilerplate Project Tutorial](https://www.youtube.com/watch?v=blaKAz5U4ew) - Razvan Vancea
 - [PactumJS Tutorial - Getting Started with API Automation Testing](https://www.youtube.com/watch?v=UHoxxgxB6t8) - Razvan Vancea
+- [PactumJS and Cucumber - API Boilerplate Project Tutorial](https://www.youtube.com/watch?v=blaKAz5U4ew) - Razvan Vancea
 - [Integrating Mochawesome HTML Reporter with PactumJS](https://youtu.be/2lNLN2QxDOk) - Razvan Vancea
+- [How to create standalone Mockserver using PactumJS in a few simple steps](https://youtu.be/5vhAMpCgEuU?si=j0sbJfiLs3m1V1iL) - Razvan Vancea
+- [How to configure Mockserver into API Tests using PactumJS](https://youtu.be/kKDf7gKZLbg?si=cJnY-71TEkTLS9cU) - Razvan Vancea
+- [Introduction To PactumJS](https://www.youtube.com/watch?v=EBVWC5LG_eA) - Aamir Mohammed Suhail
 - [NestJs Course for Beginners - Create a REST API](https://www.youtube.com/watch?v=GHTA143_b-s&t=10390s) - Vladimir Agaev
 - [TDD for an API (ExpressJS) using PactumJS and CucumberJS (BDD)](https://www.youtube.com/watch?v=ISAjES_Gklc) - Eddie Jaoude
 - [TA Tool Evaluation - PactumJS](https://community-z.com/events/idea-pool-ta-tool-evaluation-pactumjs/talks/13414) - Milan Horvath


### PR DESCRIPTION
In the media section, I included 2 links for YouTube tutorials regarding mock server standalone & configuring mock server into api tests