### PR TITLE
Documentation update for follow redirects

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -168,6 +168,7 @@ const api_sidebar = [
       { text: 'setBaseUrl', link: '/api/settings/setBaseUrl', },
       { text: 'setDefaultHeaders', link: '/api/settings/setDefaultHeaders', },
       { text: 'setDefaultTimeout', link: '/api/settings/setDefaultTimeout', },
+      { text: 'setDefaultFollowRedirects', link: '/api/settings/setDefaultFollowRedirects', },
       { text: 'setLogLevel', link: '/api/settings/setLogLevel', },
       { text: 'setLogger', link: '/api/settings/setLogger', },
       { text: 'setJsonLikeAdapter', link: '/api/settings/setJsonLikeAdapter', },

--- a/docs/api/requests/withCore.md
+++ b/docs/api/requests/withCore.md
@@ -9,6 +9,10 @@ tags:
 
 To further customize the request, pactum allows us directly set the [core options](https://nodejs.org/api/http.html#httprequesturl-options-callback) of the request.
 
+::: warning WARNING 
+If `withCore` is used at the end in request chaining, all [http core options](https://nodejs.org/api/http.html#httprequesturl-options-callback) provided in `withCore` will take precedence and they will override any previously values.
+:::
+
 ## Syntax
 
 ```js
@@ -63,6 +67,50 @@ await spec()
   .expectStatus(200);
 ```
 
-::: warning WARNING 
-If `withCore` is used at the end in request chaining, all [http core options](https://nodejs.org/api/http.html#httprequesturl-options-callback) provided in `withCore` will take precedence and they will override any previously values.
-:::
+### Https Agent with SSL certificates
+
+```js
+// If you have the cert/key pair
+const { spec } = require('pactum');
+const https = require('https');
+const fs = require('fs');
+
+const key = fs.readFileSync("server.key")
+const cert = fs.readFileSync("server.crt")
+
+const agent = new https.Agent({
+  cert: cert,
+  key: key,
+});
+
+await spec()
+    .get('<https url>')
+    .withCore({agent: agent })
+    .expectStatus(200)
+```
+
+### Https Agent with self signed / private SSL certificates
+
+```js
+const { spec } = require('pactum');
+const https = require('https');
+const fs = require('fs');
+
+// If you have the cert/key pair
+const key = fs.readFileSync("server.key")
+const cert = fs.readFileSync("server.crt")
+
+const agent = new https.Agent({
+  cert: cert, // Optional - add if cert available 
+  key: key, // Optional - add if key is available 
+  rejectUnauthorized: false // Ignore  certificate errors
+});
+
+await spec()
+    .get('<https url>')
+    .withCore({agent: agent })
+    .expectStatus(200)
+```
+
+
+

--- a/docs/api/requests/withFollowRedirects.md
+++ b/docs/api/requests/withFollowRedirects.md
@@ -8,22 +8,36 @@ tags:
 
 Follows redirection.
 
+::: tip Tip
+Default value for follow redirects is false / disabled
+:::
+
 ## Syntax
 
 ```js
 withFollowRedirects(follow)
 ```
-
-- `follow` (**boolean**) - follow redirect.
+follow redirects option
+- `follow` (**boolean**) - follow redirect toggle, to enable follow redirects and use default follow redirect count of 20.
+- `follow` (**number**) - follow redirect, count of redirects. Allowed values are >=0.
 
 ## Usage
 
 #### ✅  Correct Usage
 
 ```js
+// 
 await spec()
   .get('/api/old/location')
-  .withFollowRedirects()
+  .withFollowRedirects(true)
+  .expectStatus(200);
+```
+
+```js
+// 
+await spec()
+  .get('/api/old/location')
+  .withFollowRedirects(5)
   .expectStatus(200);
 ```
 
@@ -32,6 +46,7 @@ await spec()
 #### General Redirection
 
 ```js
+// toggle follow redirects with default follow-redirect count
 const { spec } = require('pactum');
 
 await spec()
@@ -40,3 +55,22 @@ await spec()
   .withFollowRedirects(true)
   .expectStatus(200);
 ```
+
+```js
+// toggle follow redirects with custom follow-redirect count
+const { spec } = require('pactum');
+
+await spec()
+  .get('https://httpbin.org/redirect-to')
+  .withQueryParams('url', 'https://httpbin.org/status/200')
+  .withFollowRedirects(2)
+  .expectStatus(200);
+```
+
+::: tip Tip
+Follow redirects count should be greater than or equal to number of redirects on the server side for the request.
+:::
+
+## See Also
+
+- [setDefaultFollowRedirects](/api/settings/setDefaultFollowRedirects)

--- a/docs/api/settings/setDefaultFollowRedirects.md
+++ b/docs/api/settings/setDefaultFollowRedirects.md
@@ -1,0 +1,80 @@
+---
+tags:
+  - redirects
+  - follow redirects
+---
+
+# setDefaultFollowRedirects
+
+set default Follow Redirects for all the requests.
+
+::: tip Tip
+Default value for follow redirects is false / disabled
+:::
+
+## Syntax
+
+```js
+setDefaultFollowRedirects(follow)
+```
+
+## Usage
+
+### ✅  Correct Usage
+
+```js
+// Boolean parameter - defaults to count 20
+request.setDefaultFollowRedirects(true)
+```
+
+```js
+// Absolute follow redirect count
+request.setDefaultFollowRedirects(5)
+```
+
+## Arguments
+
+#### > follow (boolean)
+
+Toggle follow redirects
+
+#### > follow (number)
+
+Toggle follow redirects and set the absolute redirect count.
+
+
+
+## Examples
+
+### Normal
+
+```js
+const { spec, request } = require('pactum');
+
+request.setDefaultFollowRedirects(true);
+
+await spec()
+  .get('https://httpbin.org/redirect-to')
+  .withQueryParams('url', 'https://httpbin.org/status/200')
+  .expectStatus(200);
+```
+
+```js
+const { spec, request } = require('pactum');
+
+request.setDefaultFollowRedirects(5);
+
+await spec()
+  .get('https://httpbin.org/redirect-to')
+  .withQueryParams('url', 'https://httpbin.org/status/200')
+  .expectStatus(200);
+```
+
+::: tip Tip
+Follow redirects count should be greater than or equal to number of redirects on the server side for the request.
+:::
+
+
+## See Also
+
+- [withFollowRedirects](/api/requests/withFollowRedirects)


### PR DESCRIPTION
closes #53 
closes #54 

**Change Summary**
* Add documentation for `setDefaultFollowRedirects` 
* Update documentation for `withFollowRedirects`
* Update documentation for `withCore` with examples of SSL certificates and Https agent